### PR TITLE
Error on import_name when a backend is a root package

### DIFF
--- a/getpaid/utils.py
+++ b/getpaid/utils.py
@@ -4,8 +4,21 @@ import sys
 
 def import_name(name):
     components = name.split('.')
-    mod = __import__('.'.join(components[0:-1]), globals(), locals(), [components[-1]])
-    return getattr(mod, components[-1])
+
+    if len(components) == 1:
+        # direct module, import the module directly
+        mod = __import__(name, globals(), locals(), [name])
+    else:
+        # the module is within another, so we
+        # need to import it from there
+        parent_path = components[0:-1]
+        module_name = components[-1]
+
+        parent_mod = __import__(
+            '.'.join(parent_path), globals(), locals(), [module_name])
+        mod = getattr(parent_mod, components[-1])
+
+    return mod
 
 
 def import_backend_modules(submodule=None):


### PR DESCRIPTION
Hi!  
When trying to make a custom backend for this application, I run into a problem when it tries to load the backend module.
I was following the instructions to create a custom backend explained on the documentation, using a django app and creating the `PaymentProccesor` on the `__init__.py` file.
Dbuggging the point of failure, I found that since the module of my backend was a root module (without parent modules), the `import_name` method was failing to import it. For some reason, it was using the `getpaid` module as the parent module (probably because that's the parent module of `utils`?), and thus failing to import my backend module.

I made a little change on the `import_name` function that seems to have fixed this issue for me, and works correctly with the `dummy` backend, so I guess it didn't break anything.
Please consider adding this modification to your repo.                          

Cheers!
