### PR TITLE
Fix example app throws TemplateSyntaxError at /paywall/fake_gateway/

### DIFF
--- a/example/paywall/templates/paywall/fake_gateway_authorization_form.html
+++ b/example/paywall/templates/paywall/fake_gateway_authorization_form.html
@@ -1,4 +1,6 @@
 {% extends "getpaid/base.html" %}
+{% load i18n %}
+
 {% block content %}
 <h1>django-getpaid fake payment gateway</h1>
 <h3>This page simulates the broker's paywall where usually you would


### PR DESCRIPTION
When I tried to launch example app and navigate through:
Home -> Order -> Checkout
I received error 
`TemplateSyntaxError at /paywall/fake_gateway/
Invalid block tag on line 8: 'blocktrans', expected 'endblock'. Did you forget to register or load this tag?`

I've added necessary load to paywall/templates/paywall/fake_gateway_authorization_form.html

After such change, example app is working again